### PR TITLE
- Using install var for setting path variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,13 +3,13 @@
 #By: Ankit Vadehra
 #Contact: ankitvad[at]gmail[dot[com]
 #License: Standard MIT License.
-INSTALL=~/.local/bin
+INSTALL=~/.local/bin/
 BASH_FILE=~/.bashrc
 bold=`tput bold`
 normal=`tput sgr0`
 mkdir -p "$INSTALL"
 cp goto "$INSTALL"
-echo 'export PATH=$PATH:~/.local/bin/' >> "$BASH_FILE"
+printf "export PATH=\"%s:$INSTALL\"\n" '$PATH' >> "$BASH_FILE"
 echo 'alias goto=". goto"' >> "$BASH_FILE"
 echo -e "Added Stuff in .bashrc"
 . ~/.bashrc

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ bold=`tput bold`
 normal=`tput sgr0`
 mkdir -p "$INSTALL"
 cp goto "$INSTALL"
-printf "export PATH=\"%s:$INSTALL\"\n" '$PATH' >> "$BASH_FILE"
+printf "PATH=\"%s:$INSTALL\"\n" '$PATH' >> "$BASH_FILE"
 echo 'alias goto=". goto"' >> "$BASH_FILE"
 echo -e "Added Stuff in .bashrc"
 . ~/.bashrc


### PR DESCRIPTION
Using the install variable now for appending to the path string.

One thing that I'm not sure about though is the \n at the end of the printf. I assumed both Mac and Linux use this newline character and this script wouldn't work on Windows anyways.
