### PR TITLE
Add support for adding to .bash_profile on Mac OS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,21 @@
 #License: Standard MIT License.
 INSTALL=~/.local/bin
 BASH_FILE=~/.bashrc
+MAC_OS_BASH_FILE=~/.bash_profile
 bold=`tput bold`
 normal=`tput sgr0`
 mkdir -p "$INSTALL"
 cp goto "$INSTALL"
-echo 'export PATH=$PATH:~/.local/bin/' >> "$BASH_FILE"
-echo 'alias goto=". goto"' >> "$BASH_FILE"
-echo -e "Added Stuff in .bashrc"
-. ~/.bashrc
+
+if [ -f $MAC_OS_BASH_FILE ]; then
+  echo 'export PATH=$PATH:~/.local/bin/' >> "$MAC_OS_BASH_FILE"
+  echo 'alias goto=". goto"' >> "$MAC_OS_BASH_FILE"
+  echo -e "Added Stuff in .bash_profile"
+  . ~/.bash_profile
+else
+  echo 'export PATH=$PATH:~/.local/bin/' >> "$BASH_FILE"
+  echo 'alias goto=". goto"' >> "$BASH_FILE"
+  echo -e "Added Stuff in .bashrc"
+  . ~/.bashrc
+fi
 exit 0


### PR DESCRIPTION
Check if user is using `.bash_profile`, then add commands to it
